### PR TITLE
Refactor/stub intercepts

### DIFF
--- a/cypress/fixtures/aLoveSupreme.json
+++ b/cypress/fixtures/aLoveSupreme.json
@@ -1,0 +1,25 @@
+{
+  "id": 205,
+  "albumArtist": "John Coltrane",
+  "title": "A Love Supreme",
+  "releaseYear": 1965,
+  "cover": "https://upload.wikimedia.org/wikipedia/en/9/9a/John_Coltrane_-_A_Love_Supreme.jpg",
+  "musicians": [
+    {
+      "name": "John Coltrane",
+      "instrument": "soprano saxophone, tenor saxophone"
+    },
+    {
+      "name": "Jimmy Garrison",
+      "instrument": "double bass"
+    },
+    {
+      "name": "Elvin Jones",
+      "instrument": "drums, gong, timpani"
+    },
+    {
+      "name": "McCoy Tyner",
+      "instrument": "piano"
+    }
+  ]
+}

--- a/cypress/fixtures/birthOfTheCool.json
+++ b/cypress/fixtures/birthOfTheCool.json
@@ -1,0 +1,45 @@
+{
+  "id": 101,
+  "albumArtist": "Miles Davis",
+  "title": "Birth of the Cool",
+  "releaseYear": 1957,
+  "cover": "https://upload.wikimedia.org/wikipedia/en/a/a8/Birth_of_the_Cool.jpg",
+  "musicians": [
+    {
+      "name": "Miles Davis",
+      "instrument": "trumpet"
+    },
+    {
+      "name": "Kai Winding",
+      "instrument": "trombone"
+    },
+    {
+      "name": "Junior Collins",
+      "instrument": "french horn"
+    },
+    {
+      "name": "Bill Barber",
+      "instrument": "tuba"
+    },
+    {
+      "name": "Lee Konitz",
+      "instrument": "alto saxophone"
+    },
+    {
+      "name": "Gerry Milligan",
+      "instrument": "baritone saxophone"
+    },
+    {
+      "name": "Al Haig",
+      "instrument": "piano"
+    },
+    {
+      "name": "Joe Shulman",
+      "instrument": "bass"
+    },
+    {
+      "name": "Max Roach",
+      "instrument": "drums"
+    }
+  ]
+}

--- a/cypress/fixtures/coltraneArtistPage.json
+++ b/cypress/fixtures/coltraneArtistPage.json
@@ -1,43 +1,41 @@
 {
-  "names": {
-      "name": "John Coltrane",
-      "id": "2",
-      "instrument": "Saxophone",
-      "photo": "https://upload.wikimedia.org/wikipedia/commons/thumb/6/6e/John_Coltrane_in_1963.jpg/1920px-John_Coltrane_in_1963.jpg",
-      "albums": [
+  "name": "John Coltrane",
+  "id": "2",
+  "instrument": "Saxophone",
+  "photo": "https://upload.wikimedia.org/wikipedia/commons/thumb/6/6e/John_Coltrane_in_1963.jpg/1920px-John_Coltrane_in_1963.jpg",
+  "albums": [
+    {
+      "id": 201,
+      "albumArtist": "John Coltrane",
+      "title": "Blue Train",
+      "releaseYear": 1958,
+      "cover": "https://upload.wikimedia.org/wikipedia/en/6/68/John_Coltrane_-_Blue_Train.jpg",
+      "musicians": [
         {
-        "id": 201,
-        "albumArtist": "John Coltrane",
-        "title": "Blue Train",
-        "releaseYear": 1958,
-        "cover": "https://upload.wikimedia.org/wikipedia/en/6/68/John_Coltrane_-_Blue_Train.jpg",
-        "musicians": [
-          {
-            "name": "John Coltrane",
-            "instrument": "tenor saxophone"
-          },
-          {
-            "name": "Lee Morgan",
-            "instrument": "trumpet"
-          },
-          {
-            "name": "Curtis Fuller",
-            "instrument": "trombone"
-          },
-          {
-            "name": "Kenny Drew",
-            "instrument": "piano"
-          },
-          {
-            "name": "Paul Chambers",
-            "instrument": "bass"
-          },
-          {
-            "name": "Philly Joe Jones",
-            "instrument": "drums"
-          }
-        ]
-      }
-    ]
-  }
+          "name": "John Coltrane",
+          "instrument": "tenor saxophone"
+        },
+        {
+          "name": "Lee Morgan",
+          "instrument": "trumpet"
+        },
+        {
+          "name": "Curtis Fuller",
+          "instrument": "trombone"
+        },
+        {
+          "name": "Kenny Drew",
+          "instrument": "piano"
+        },
+        {
+          "name": "Paul Chambers",
+          "instrument": "bass"
+        },
+        {
+          "name": "Philly Joe Jones",
+          "instrument": "drums"
+        }
+      ]
+    }
+  ]
 }

--- a/cypress/fixtures/coltraneArtistPage.json
+++ b/cypress/fixtures/coltraneArtistPage.json
@@ -1,0 +1,43 @@
+{
+  "names": {
+      "name": "John Coltrane",
+      "id": "2",
+      "instrument": "Saxophone",
+      "photo": "https://upload.wikimedia.org/wikipedia/commons/thumb/6/6e/John_Coltrane_in_1963.jpg/1920px-John_Coltrane_in_1963.jpg",
+      "albums": [
+        {
+        "id": 201,
+        "albumArtist": "John Coltrane",
+        "title": "Blue Train",
+        "releaseYear": 1958,
+        "cover": "https://upload.wikimedia.org/wikipedia/en/6/68/John_Coltrane_-_Blue_Train.jpg",
+        "musicians": [
+          {
+            "name": "John Coltrane",
+            "instrument": "tenor saxophone"
+          },
+          {
+            "name": "Lee Morgan",
+            "instrument": "trumpet"
+          },
+          {
+            "name": "Curtis Fuller",
+            "instrument": "trombone"
+          },
+          {
+            "name": "Kenny Drew",
+            "instrument": "piano"
+          },
+          {
+            "name": "Paul Chambers",
+            "instrument": "bass"
+          },
+          {
+            "name": "Philly Joe Jones",
+            "instrument": "drums"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/cypress/fixtures/coltraneSearchData.json
+++ b/cypress/fixtures/coltraneSearchData.json
@@ -1,0 +1,27 @@
+[
+  {
+    "id": 205,
+    "albumArtist": "John Coltrane",
+    "title": "A Love Supreme",
+    "releaseYear": 1965,
+    "cover": "https://upload.wikimedia.org/wikipedia/en/9/9a/John_Coltrane_-_A_Love_Supreme.jpg",
+    "musicians": [
+      {
+        "name": "John Coltrane",
+        "instrument": "soprano saxophone, tenor saxophone"
+      },
+      {
+        "name": "Jimmy Garrison",
+        "instrument": "double bass"
+      },
+      {
+        "name": "Elvin Jones",
+        "instrument": "drums, gong, timpani"
+      },
+      {
+        "name": "McCoy Tyner",
+        "instrument": "piano"
+      }
+    ]
+  }
+]

--- a/cypress/fixtures/jimmyGarrisonSearchData.json
+++ b/cypress/fixtures/jimmyGarrisonSearchData.json
@@ -1,0 +1,126 @@
+[
+  {
+    "id": 204,
+    "albumArtist": "John Coltrane",
+    "title": "Impressions",
+    "releaseYear": 1963,
+    "cover": "https://upload.wikimedia.org/wikipedia/en/5/5c/Impressions_cover.jpg",
+    "musicians": [
+      {
+        "name": "John Coltrane",
+        "instrument": "soprano saxophone, tenor saxophone"
+      },
+      {
+        "name": "Eric Dolphy",
+        "instrument": "bass clarinet"
+      },
+      {
+        "name": "McCoy Tyner",
+        "instrument": "paino"
+      },
+      {
+        "name": "Jimmy Garrison",
+        "instrument": "double bass"
+      },
+      {
+        "name": "Reggie Workman",
+        "instrument": "double bass"
+      },
+      {
+        "name": "Elvin Jones",
+        "instrument": "drums"
+      },
+      {
+        "name": "Roy Haynes",
+        "instrument": "drums"
+      }
+    ]
+  },
+  {
+    "id": 205,
+    "albumArtist": "John Coltrane",
+    "title": "A Love Supreme",
+    "releaseYear": 1965,
+    "cover": "https://upload.wikimedia.org/wikipedia/en/9/9a/John_Coltrane_-_A_Love_Supreme.jpg",
+    "musicians": [
+      {
+        "name": "John Coltrane",
+        "instrument": "soprano saxophone, tenor saxophone"
+      },
+      {
+        "name": "Jimmy Garrison",
+        "instrument": "double bass"
+      },
+      {
+        "name": "Elvin Jones",
+        "instrument": "drums, gong, timpani"
+      },
+      {
+        "name": "McCoy Tyner",
+        "instrument": "piano"
+      }
+    ]
+  },
+  {
+    "id": 206,
+    "albumArtist": "John Coltrane",
+    "title": "Expression",
+    "releaseYear": 1967,
+    "cover": "https://upload.wikimedia.org/wikipedia/en/2/25/ColtraneExpression.jpg",
+    "musicians": [
+      {
+        "name": "John Coltrane",
+        "instrument": "tenor saxophone, flute"
+      },
+      {
+        "name": "Pharoah Sanders",
+        "instrument": "flute, piccolo, tambourine"
+      },
+      {
+        "name": "Alice Coltrane",
+        "instrument": "piano"
+      },
+      {
+        "name": "Jimmy Garrison",
+        "instrument": "bass"
+      },
+      {
+        "name": "Rashied Ali",
+        "instrument": "drums"
+      }
+    ]
+  },
+  {
+    "id": 504,
+    "albumArtist": "Duke Ellington and John Coltrane",
+    "title": "Duke Ellington & John Coltrane",
+    "releaseYear": 1963,
+    "cover": "https://upload.wikimedia.org/wikipedia/en/2/2a/Duke_Ellington_%26_John_Coltrane.jpg",
+    "musicians": [
+      {
+        "name": "Duke Ellington",
+        "instrument": "piano"
+      },
+      {
+        "name": "John Coltrane",
+        "instrument": "tenor saxophone, soprano saxophone"
+      },
+      {
+        "name": "Jimmy Garrison",
+        "instrument": "bass"
+      },
+      {
+        "name": "Aaron Bell",
+        "instrument": "bass"
+      },
+      {
+        "name": "Elvin Jones",
+        "instrument": "drums"
+      },
+      {
+        "name": "Sam Woodyard",
+        "instrument": "drums"
+      }
+    ]
+  }
+]

--- a/cypress/fixtures/milesDavisArtistPage.json
+++ b/cypress/fixtures/milesDavisArtistPage.json
@@ -1,0 +1,45 @@
+{
+  "name": "Miles Davis",
+  "id": "1",
+  "instrument": "Trumpet",
+  "photo": "https://upload.wikimedia.org/wikipedia/commons/thumb/2/24/Miles_Davis_by_Palumbo_cropped.jpg/1280px-Miles_Davis_by_Palumbo_cropped.jpg",
+  "albums": [
+    {
+      "id": 103,
+      "albumArtist": "Miles Davis",
+      "title": "Kind of Blue",
+      "releaseYear": 1959,
+      "cover": "https://upload.wikimedia.org/wikipedia/en/9/9c/MilesDavisKindofBlue.jpg",
+      "musicians": [
+        {
+          "name": "Miles Davis",
+          "instrument": "trumpet"
+        },
+        {
+          "name": "Julian \"Cannonball\" Adderley",
+          "instrument": "alto saxophone"
+        },
+        {
+          "name": "John Coltrane",
+          "instrument": "tenor saxophone"
+        },
+        {
+          "name": "Bill Evans",
+          "instrument": "piano"
+        },
+        {
+          "name": "Wynton Kelley",
+          "instrument": "piano"
+        },
+        {
+          "name": "Paul Chambers",
+          "instrument": "double bass"
+        },
+        {
+          "name": "Jimmy Cobb",
+          "instrument": "drums"
+        }
+      ]
+    }
+  ]
+}

--- a/cypress/fixtures/milesDavisSearchData.json
+++ b/cypress/fixtures/milesDavisSearchData.json
@@ -1,37 +1,45 @@
 [
   {
-    "id": 103,
+    "id": 101,
     "albumArtist": "Miles Davis",
-    "title": "Kind of Blue",
-    "releaseYear": 1959,
-    "cover": "https://upload.wikimedia.org/wikipedia/en/9/9c/MilesDavisKindofBlue.jpg",
+    "title": "Birth of the Cool",
+    "releaseYear": 1957,
+    "cover": "https://upload.wikimedia.org/wikipedia/en/a/a8/Birth_of_the_Cool.jpg",
     "musicians": [
       {
         "name": "Miles Davis",
         "instrument": "trumpet"
       },
       {
-        "name": "Julian \"Cannonball\" Adderley",
+        "name": "Kai Winding",
+        "instrument": "trombone"
+      },
+      {
+        "name": "Junior Collins",
+        "instrument": "french horn"
+      },
+      {
+        "name": "Bill Barber",
+        "instrument": "tuba"
+      },
+      {
+        "name": "Lee Konitz",
         "instrument": "alto saxophone"
       },
       {
-        "name": "John Coltrane",
-        "instrument": "tenor saxophone"
+        "name": "Gerry Milligan",
+        "instrument": "baritone saxophone"
       },
       {
-        "name": "Bill Evans",
+        "name": "Al Haig",
         "instrument": "piano"
       },
       {
-        "name": "Wynton Kelley",
-        "instrument": "piano"
-        },
-      {
-        "name": "Paul Chambers",
-        "instrument": "double bass"
+        "name": "Joe Shulman",
+        "instrument": "bass"
       },
       {
-        "name": "Jimmy Cobb",
+        "name": "Max Roach",
         "instrument": "drums"
       }
     ]

--- a/cypress/fixtures/milesDavisSearchData.json
+++ b/cypress/fixtures/milesDavisSearchData.json
@@ -1,0 +1,39 @@
+[
+  {
+    "id": 103,
+    "albumArtist": "Miles Davis",
+    "title": "Kind of Blue",
+    "releaseYear": 1959,
+    "cover": "https://upload.wikimedia.org/wikipedia/en/9/9c/MilesDavisKindofBlue.jpg",
+    "musicians": [
+      {
+        "name": "Miles Davis",
+        "instrument": "trumpet"
+      },
+      {
+        "name": "Julian \"Cannonball\" Adderley",
+        "instrument": "alto saxophone"
+      },
+      {
+        "name": "John Coltrane",
+        "instrument": "tenor saxophone"
+      },
+      {
+        "name": "Bill Evans",
+        "instrument": "piano"
+      },
+      {
+        "name": "Wynton Kelley",
+        "instrument": "piano"
+        },
+      {
+        "name": "Paul Chambers",
+        "instrument": "double bass"
+      },
+      {
+        "name": "Jimmy Cobb",
+        "instrument": "drums"
+      }
+    ]
+  }
+]

--- a/cypress/fixtures/musiciansData.json
+++ b/cypress/fixtures/musiciansData.json
@@ -1,0 +1,12 @@
+{
+  "names": [
+    {
+      "name": "Miles Davis",
+      "id": "1"
+    },
+    {
+      "name": "John Coltrane",
+      "id": "2"
+    }
+  ]
+}

--- a/cypress/integration/Album_spec.js
+++ b/cypress/integration/Album_spec.js
@@ -1,5 +1,9 @@
 describe('Album page', () => {
   it('should have album details and a list of musicians that can be added to and removed from the collaboration form', () => {
+    cy.fixture('aLoveSupreme.json').as('aLoveSupremeData')
+      .then((json) => {
+        cy.intercept('GET', 'http://localhost:3000/api/v1/album/205', json)
+      })
     cy.visit('http://localhost:3001/album/205')
       .get('.collaborators-form')
       .get('.album-info-container')
@@ -21,6 +25,10 @@ describe('Album page', () => {
   })
 
   it('should not be able to add players that are already included in the form', () => {
+    cy.fixture('aLoveSupreme.json').as('aLoveSupremeData')
+      .then((json) => {
+        cy.intercept('GET', 'http://localhost:3000/api/v1/album/205', json)
+      })
     cy.visit('http://localhost:3001/album/205')
       .get('.name-and-button-section')
       .find('.add-collaborator-button').eq(1).click()
@@ -32,6 +40,18 @@ describe('Album page', () => {
   })
 
   it('should be able to click a button to navigate to the collaborations page once two musicians are selected', () => {
+    cy.fixture('aLoveSupreme.json').as('aLoveSupremeData')
+      .then((json) => {
+        cy.intercept('GET', 'http://localhost:3000/api/v1/album/205', json)
+      })
+    cy.fixture('jimmyGarrisonSearchData.json').as('jimmyGarrisonData')
+      .then((json) => {
+        cy.intercept('GET', 'http://localhost:3000/api/v1/appearances/jimmy%20garrison', json)
+      })
+    cy.fixture('coltraneSearchData.json').as('coltraneSearchData')
+      .then((json) => {
+        cy.intercept('GET', 'http://localhost:3000/api/v1/appearances/John%20Coltrane', json)
+      })
     cy.visit('http://localhost:3001/album/205')
       .get('.name-and-button-section')
       .find('.add-collaborator-button').eq(0).click()

--- a/cypress/integration/Artist_spec.js
+++ b/cypress/integration/Artist_spec.js
@@ -1,5 +1,9 @@
 describe('Artist page user flow', () => {
   it('should see artist details, collaborator section, and be able to add and remove the artist from the collaborator form', () => {
+    cy.fixture('coltraneArtistPage.json').as('coltraneArtistPage')
+      .then((json) => {
+        cy.intercept('GET', 'http://localhost:3000/api/v1/musicians/2', json)
+      })
     cy.visit('http://localhost:3001/artist/2')
       .get('.collaborators-form')
       .get('.middle-button')
@@ -20,7 +24,7 @@ describe('Artist page user flow', () => {
       .should('not.be.disabled')
       .get('.albums-container')
       .get('.album-link')
-      .contains('A Love Supreme').click()
-      .url().should('eq', 'http://localhost:3001/album/205')
+      .contains('Blue Train').click()
+      .url().should('eq', 'http://localhost:3001/album/201')
   })
 })

--- a/cypress/integration/Home_spec.js
+++ b/cypress/integration/Home_spec.js
@@ -61,6 +61,61 @@ describe('Home page and search results', () => {
   })
 
   it('should render instructions, a list of musician links that navigate to artist pages, and a navigable header that navigates back home', () => {
+    cy.intercept('GET', 'http://localhost:3000/api/v1/musicians', {
+      "names": [
+        {
+          "name": "Miles Davis",
+          "id": "1"
+        },
+        {
+          "name": "John Coltrane",
+          "id": "2"
+        }
+      ]
+    })
+    cy.intercept('GET', 'http://localhost:3000/api/v1/musicians/2', {
+      "names": {
+        "name": "John Coltrane",
+        "id": "2",
+        "instrument": "Saxophone",
+        "photo": "https://upload.wikimedia.org/wikipedia/commons/thumb/6/6e/John_Coltrane_in_1963.jpg/1920px-John_Coltrane_in_1963.jpg",
+        "albums": [
+          {
+          "id": 201,
+          "albumArtist": "John Coltrane",
+          "title": "Blue Train",
+          "releaseYear": 1958,
+          "cover": "https://upload.wikimedia.org/wikipedia/en/6/68/John_Coltrane_-_Blue_Train.jpg",
+          "musicians": [
+            {
+              "name": "John Coltrane",
+              "instrument": "tenor saxophone"
+            },
+            {
+              "name": "Lee Morgan",
+              "instrument": "trumpet"
+            },
+            {
+              "name": "Curtis Fuller",
+              "instrument": "trombone"
+            },
+            {
+              "name": "Kenny Drew",
+              "instrument": "piano"
+            },
+            {
+              "name": "Paul Chambers",
+              "instrument": "bass"
+            },
+            {
+              "name": "Philly Joe Jones",
+              "instrument": "drums"
+            }
+          ]
+        }
+      ]
+    }
+    })
     cy.visit('http://localhost:3001/')
       .get('.instructions')
       .get('.artist-link')

--- a/cypress/integration/Home_spec.js
+++ b/cypress/integration/Home_spec.js
@@ -1,45 +1,14 @@
 describe('Home page and search results', () => {
   
   it('should render the navbar with a search bar that navigates to a results page', () => {
-    cy.intercept('GET', 'http://localhost:3000/api/v1/musicians', {
-      "names": [
-        {
-          "name": "Miles Davis",
-          "id": "1"
-        },
-        {
-          "name": "John Coltrane",
-          "id": "2"
-        }
-      ]
-    })
-    cy.intercept('GET', 'http://localhost:3000/api/v1/appearances/John%20Coltrane', [
-      {
-        "id": 205,
-        "albumArtist": "John Coltrane",
-        "title": "A Love Supreme",
-        "releaseYear": 1965,
-        "cover": "https://upload.wikimedia.org/wikipedia/en/9/9a/John_Coltrane_-_A_Love_Supreme.jpg",
-        "musicians": [
-          {
-            "name": "John Coltrane",
-            "instrument": "soprano saxophone, tenor saxophone"
-          },
-          {
-            "name": "Jimmy Garrison",
-            "instrument": "double bass"
-          },
-          {
-            "name": "Elvin Jones",
-            "instrument": "drums, gong, timpani"
-          },
-          {
-            "name": "McCoy Tyner",
-            "instrument": "piano"
-          }
-        ]
-      }
-    ])
+    cy.fixture('musiciansData.json').as('musiciansData')
+      .then((json) => {
+        cy.intercept('GET', 'http://localhost:3000/api/v1/musicians', json)
+      })
+    cy.fixture('coltraneSearchData.json').as('coltraneSearchData')
+      .then((json) => {
+        cy.intercept('GET', 'http://localhost:3000/api/v1/appearances/John%20Coltrane', json)
+      })
     cy.visit('http://localhost:3001/')
       .get('nav')
       .get('h1')
@@ -61,61 +30,14 @@ describe('Home page and search results', () => {
   })
 
   it('should render instructions, a list of musician links that navigate to artist pages, and a navigable header that navigates back home', () => {
-    cy.intercept('GET', 'http://localhost:3000/api/v1/musicians', {
-      "names": [
-        {
-          "name": "Miles Davis",
-          "id": "1"
-        },
-        {
-          "name": "John Coltrane",
-          "id": "2"
-        }
-      ]
-    })
-    cy.intercept('GET', 'http://localhost:3000/api/v1/musicians/2', {
-      "names": {
-        "name": "John Coltrane",
-        "id": "2",
-        "instrument": "Saxophone",
-        "photo": "https://upload.wikimedia.org/wikipedia/commons/thumb/6/6e/John_Coltrane_in_1963.jpg/1920px-John_Coltrane_in_1963.jpg",
-        "albums": [
-          {
-          "id": 201,
-          "albumArtist": "John Coltrane",
-          "title": "Blue Train",
-          "releaseYear": 1958,
-          "cover": "https://upload.wikimedia.org/wikipedia/en/6/68/John_Coltrane_-_Blue_Train.jpg",
-          "musicians": [
-            {
-              "name": "John Coltrane",
-              "instrument": "tenor saxophone"
-            },
-            {
-              "name": "Lee Morgan",
-              "instrument": "trumpet"
-            },
-            {
-              "name": "Curtis Fuller",
-              "instrument": "trombone"
-            },
-            {
-              "name": "Kenny Drew",
-              "instrument": "piano"
-            },
-            {
-              "name": "Paul Chambers",
-              "instrument": "bass"
-            },
-            {
-              "name": "Philly Joe Jones",
-              "instrument": "drums"
-            }
-          ]
-        }
-      ]
-    }
-    })
+    cy.fixture('musiciansData.json').as('musiciansData')
+      .then((json) => {
+        cy.intercept('GET', 'http://localhost:3000/api/v1/musicians', json)
+      })
+    cy.fixture('coltraneArtistPage.json').as('coltraneArtistPage')
+      .then((json) => {
+        cy.intercept('GET', 'http://localhost:3000/api/v1/musicians/2', json)
+      })
     cy.visit('http://localhost:3001/')
       .get('.instructions')
       .get('.artist-link')

--- a/cypress/integration/Home_spec.js
+++ b/cypress/integration/Home_spec.js
@@ -1,5 +1,45 @@
 describe('Home page and search results', () => {
+  
   it('should render the navbar with a search bar that navigates to a results page', () => {
+    cy.intercept('GET', 'http://localhost:3000/api/v1/musicians', {
+      "names": [
+        {
+          "name": "Miles Davis",
+          "id": "1"
+        },
+        {
+          "name": "John Coltrane",
+          "id": "2"
+        }
+      ]
+    })
+    cy.intercept('GET', 'http://localhost:3000/api/v1/appearances/John%20Coltrane', [
+      {
+        "id": 205,
+        "albumArtist": "John Coltrane",
+        "title": "A Love Supreme",
+        "releaseYear": 1965,
+        "cover": "https://upload.wikimedia.org/wikipedia/en/9/9a/John_Coltrane_-_A_Love_Supreme.jpg",
+        "musicians": [
+          {
+            "name": "John Coltrane",
+            "instrument": "soprano saxophone, tenor saxophone"
+          },
+          {
+            "name": "Jimmy Garrison",
+            "instrument": "double bass"
+          },
+          {
+            "name": "Elvin Jones",
+            "instrument": "drums, gong, timpani"
+          },
+          {
+            "name": "McCoy Tyner",
+            "instrument": "piano"
+          }
+        ]
+      }
+    ])
     cy.visit('http://localhost:3001/')
       .get('nav')
       .get('h1')

--- a/cypress/integration/SearchResults_spec.js
+++ b/cypress/integration/SearchResults_spec.js
@@ -1,5 +1,25 @@
 describe('Search Results user flow', () => {
   it('should navigate to a search results page when searched from anywhere in the app', () => {
+    cy.fixture('musiciansData.json').as('musiciansData')
+      .then((json) => {
+        cy.intercept('GET', 'http://localhost:3000/api/v1/musicians', json)
+      })
+    cy.fixture('milesDavisSearchData.json').as('milesDavisSearchData')
+      .then((json) => {
+        cy.intercept('GET', 'http://localhost:3000/api/v1/appearances/miles%20davis', json)
+      })
+    cy.fixture('coltraneSearchData.json').as('coltraneSearchData')
+      .then((json) => {
+        cy.intercept('GET', 'http://localhost:3000/api/v1/appearances/John%20Coltrane', json)
+      })
+    cy.fixture('aLoveSupreme.json').as('aLoveSupremeData')
+      .then((json) => {
+        cy.intercept('GET', 'http://localhost:3000/api/v1/album/205', json)
+      })
+    cy.fixture('coltraneArtistPage.json').as('coltraneArtistPage')
+      .then((json) => {
+        cy.intercept('GET', 'http://localhost:3000/api/v1/musicians/2', json)
+      })
     cy.visit('http://localhost:3001/')
       .get('.search-bar')
       .type('miles davis{enter}')
@@ -8,14 +28,14 @@ describe('Search Results user flow', () => {
       .get('.search-bar')
       .type('miles davis{enter}')
       .url().should('eq', 'http://localhost:3001/search?miles%20davis')
-      .visit('http://localhost:3001/album/201')
+      .visit('http://localhost:3001/album/205')
       .get('.search-bar')
       .type('miles davis{enter}')
       .url().should('eq', 'http://localhost:3001/search?miles%20davis')
       .get('.search-bar')
       .type('john coltrane{enter}')
       .url().should('eq', 'http://localhost:3001/search?john%20coltrane')
-      .visit('http://localhost:3001/album/201')
+      .visit('http://localhost:3001/album/205')
       .get('.add-collaborator-button').eq(0).click()
       .get('.add-collaborator-button').eq(1).click()
       .get('.middle-button').click()
@@ -25,6 +45,10 @@ describe('Search Results user flow', () => {
   })
 
   it('should be able to add the search parameters to the collaborators form unless two musicians are already selected', () => {
+    cy.fixture('musiciansData.json').as('musiciansData')
+      .then((json) => {
+        cy.intercept('GET', 'http://localhost:3000/api/v1/musicians', json)
+      })
     cy.visit('http://localhost:3001/')
       .get('.search-bar')
       .type('miles davis{enter}')
@@ -46,6 +70,10 @@ describe('Search Results user flow', () => {
   })
 
   it('should display search results with navigable links to album and artist pages', () => {
+    cy.fixture('musiciansData.json').as('musiciansData')
+      .then((json) => {
+        cy.intercept('GET', 'http://localhost:3000/api/v1/musicians', json)
+      })
     cy.visit('http://localhost:3001/')
       .get('.search-bar')
       .type('miles davis{enter}')

--- a/cypress/integration/SearchResults_spec.js
+++ b/cypress/integration/SearchResults_spec.js
@@ -49,6 +49,10 @@ describe('Search Results user flow', () => {
       .then((json) => {
         cy.intercept('GET', 'http://localhost:3000/api/v1/musicians', json)
       })
+    cy.fixture('milesDavisArtistPage.json').as('milesDavisArtistPage')
+      .then((json) => {
+        cy.intercept('GET', 'http://localhost:3000/api/v1/musicians/1', json)
+      })
     cy.visit('http://localhost:3001/')
       .get('.search-bar')
       .type('miles davis{enter}')
@@ -73,6 +77,18 @@ describe('Search Results user flow', () => {
     cy.fixture('musiciansData.json').as('musiciansData')
       .then((json) => {
         cy.intercept('GET', 'http://localhost:3000/api/v1/musicians', json)
+      })
+    cy.fixture('milesDavisArtistPage.json').as('milesDavisArtistPage')
+      .then((json) => {
+        cy.intercept('GET', 'http://localhost:3000/api/v1/musicians/1', json)
+      })
+    cy.fixture('birthOfTheCool.json').as('birthOfTheCool')
+      .then((json) => {
+        cy.intercept('GET', 'http://localhost:3000/api/v1/album/101', json)
+      })
+    cy.fixture('milesDavisSearchData.json').as('milesDavisSearchData')
+      .then((json) => {
+        cy.intercept('GET', 'http://localhost:3000/api/v1/appearances/miles%20davis', json)
       })
     cy.visit('http://localhost:3001/')
       .get('.search-bar')


### PR DESCRIPTION
Is this a feature, refactor, or bug fix?
- refactor - stub all network requests in Cypress

What does it fix?
- Server errors and expensive requests for testing

What changes were made?
- Added fixtures and intercepted all requests with stubs

Additional comments?
- no